### PR TITLE
refactor!: PoSQLUnaryOP to accept sqlparser::ast::UnaryOP

### DIFF
--- a/crates/proof-of-sql/src/base/database/column_operation_error.rs
+++ b/crates/proof-of-sql/src/base/database/column_operation_error.rs
@@ -1,7 +1,7 @@
 use crate::base::{database::ColumnType, math::decimal::DecimalError};
 use alloc::string::String;
 use core::result::Result;
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
+use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator as PoSqlUnaryOperator};
 use snafu::Snafu;
 
 /// Errors from operations on columns.
@@ -31,7 +31,7 @@ pub enum ColumnOperationError {
     #[snafu(display("{operator:?}(operand: {operand_type:?}) is not supported"))]
     UnaryOperationInvalidColumnType {
         /// `UnaryOperator` that caused the error
-        operator: UnaryOperator,
+        operator: PoSqlUnaryOperator,
         /// `ColumnType` of the operand
         operand_type: ColumnType,
     },

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -1,14 +1,11 @@
 use super::{ExpressionEvaluationError, ExpressionEvaluationResult};
-use crate::{
-    base::{
-        database::{OwnedColumn, OwnedTable},
-        math::{
-            decimal::{try_convert_intermediate_decimal_to_scalar, DecimalError, Precision},
-            BigDecimalExt,
-        },
-        scalar::Scalar,
+use crate::base::{
+    database::{OwnedColumn, OwnedTable},
+    math::{
+        decimal::{try_convert_intermediate_decimal_to_scalar, DecimalError, Precision},
+        BigDecimalExt,
     },
-    sql::parse::ConversionError::UnsupportedUnaryOperator,
+    scalar::Scalar,
 };
 use alloc::{format, string::ToString, vec};
 use proof_of_sql_parser::{
@@ -79,7 +76,8 @@ impl<S: Scalar> OwnedTable<S> {
         let sqlparser_op: UnaryOperator = op.into();
         match sqlparser_op {
             UnaryOperator::Not => Ok(column.element_wise_not()?),
-            _ => Err(UnsupportedUnaryOperator {
+            // For unsupported unary operators
+            _ => Err(ExpressionEvaluationError::UnsupportedUnaryOperator {
                 op: format!("{:?}", sqlparser_op),
             }),
         }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation.rs
@@ -1,16 +1,18 @@
 use super::{ExpressionEvaluationError, ExpressionEvaluationResult};
-use crate::base::{
-    database::{OwnedColumn, OwnedTable},
-    math::{
-        decimal::{try_convert_intermediate_decimal_to_scalar, DecimalError, Precision},
-        BigDecimalExt,
+use crate::{
+    base::{
+        database::{OwnedColumn, OwnedTable},
+        math::{
+            decimal::{try_convert_intermediate_decimal_to_scalar, DecimalError, Precision},
+            BigDecimalExt,
+        },
+        scalar::Scalar,
     },
-    scalar::Scalar,
-    sql::parse::ConversionError,
+    sql::parse::ConversionError::UnsupportedUnaryOperator,
 };
 use alloc::{format, string::ToString, vec};
 use proof_of_sql_parser::{
-    intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator as PoSqlUnaryOperator,},
+    intermediate_ast::{BinaryOperator, Expression, Literal, UnaryOperator as PoSqlUnaryOperator},
     Identifier,
 };
 use sqlparser::ast::UnaryOperator;
@@ -77,7 +79,7 @@ impl<S: Scalar> OwnedTable<S> {
         let sqlparser_op: UnaryOperator = op.into();
         match sqlparser_op {
             UnaryOperator::Not => Ok(column.element_wise_not()?),
-            _ => Err(ConversionError::UnsupportedUnaryOperator {
+            _ => Err(UnsupportedUnaryOperator {
                 op: format!("{:?}", sqlparser_op),
             }),
         }

--- a/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
+++ b/crates/proof-of-sql/src/base/database/expression_evaluation_error.rs
@@ -30,6 +30,12 @@ pub enum ExpressionEvaluationError {
         /// The underlying source error
         source: DecimalError,
     },
+    /// Unsupported unary operator
+    #[snafu(display("Unsupported unary operator: {op}"))]
+    UnsupportedUnaryOperator {
+        /// The unsupported unary operator
+        op: String,
+    },
 }
 
 /// Result type for expression evaluation

--- a/crates/proof-of-sql/src/base/database/owned_column_operation.rs
+++ b/crates/proof-of-sql/src/base/database/owned_column_operation.rs
@@ -16,7 +16,7 @@ use crate::base::{
     scalar::Scalar,
 };
 use core::ops::{Add, Div, Mul, Sub};
-use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator};
+use proof_of_sql_parser::intermediate_ast::{BinaryOperator, UnaryOperator as PoSqlUnaryOperator};
 
 impl<S: Scalar> OwnedColumn<S> {
     /// Element-wise NOT operation for a column
@@ -24,7 +24,7 @@ impl<S: Scalar> OwnedColumn<S> {
         match self {
             Self::Boolean(values) => Ok(Self::Boolean(slice_not(values))),
             _ => Err(ColumnOperationError::UnaryOperationInvalidColumnType {
-                operator: UnaryOperator::Not,
+                operator: PoSqlUnaryOperator::Not,
                 operand_type: self.column_type(),
             }),
         }

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -12,17 +12,21 @@ use crate::{
     sql::{
         parse::{
             dyn_proof_expr_builder::DecimalError::{InvalidPrecision, InvalidScale},
-            ConversionError::DecimalConversionError,
+            ConversionError::{DecimalConversionError, UnsupportedUnaryOperator},
         },
         proof_exprs::{ColumnExpr, DynProofExpr, ProofExpr},
     },
 };
 use alloc::{borrow::ToOwned, boxed::Box, format, string::ToString};
 use proof_of_sql_parser::{
-    intermediate_ast::{AggregationOperator, BinaryOperator, Expression, Literal, UnaryOperator},
+    intermediate_ast::{
+        AggregationOperator, BinaryOperator, Expression, Literal,
+        UnaryOperator as PoSqlUnaryOperator,
+    },
     posql_time::{PoSQLTimeUnit, PoSQLTimestampError},
     Identifier,
 };
+use sqlparser::ast::UnaryOperator;
 
 /// Builder that enables building a `proofs::sql::proof_exprs::DynProofExpr` from
 /// a `proof_of_sql_parser::intermediate_ast::Expression`.
@@ -130,12 +134,17 @@ impl DynProofExprBuilder<'_> {
 
     fn visit_unary_expr(
         &self,
-        op: UnaryOperator,
+        op: PoSqlUnaryOperator,
         expr: &Expression,
     ) -> Result<DynProofExpr, ConversionError> {
         let expr = self.visit_expr(expr);
-        match op {
+        let sqlparser_op: UnaryOperator = op.into();
+        match sqlparser_op {
             UnaryOperator::Not => DynProofExpr::try_new_not(expr?),
+            // Handle unsupported operators
+            _ => Err(ConversionError::UnsupportedUnaryOperator {
+                op: format!("{:?}", sqlparser_op),
+            }),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/dyn_proof_expr_builder.rs
@@ -142,7 +142,7 @@ impl DynProofExprBuilder<'_> {
         match sqlparser_op {
             UnaryOperator::Not => DynProofExpr::try_new_not(expr?),
             // Handle unsupported operators
-            _ => Err(ConversionError::UnsupportedUnaryOperator {
+            _ => Err(UnsupportedUnaryOperator {
                 op: format!("{:?}", sqlparser_op),
             }),
         }

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -139,6 +139,13 @@ pub enum ConversionError {
         /// The underlying error
         error: String,
     },
+
+    #[snafu(display("Unary operator '{op}' is not supported."))]
+    /// Unsupported unary operation
+    UnsupportedUnaryOperator {
+        /// The unary operator that is unsupported
+        op: String,
+    },
 }
 
 impl From<String> for ConversionError {

--- a/crates/proof-of-sql/src/sql/parse/error.rs
+++ b/crates/proof-of-sql/src/sql/parse/error.rs
@@ -140,7 +140,7 @@ pub enum ConversionError {
         error: String,
     },
 
-    #[snafu(display("Unary operator '{op}' is not supported."))]
+    #[snafu(display("Unsupported unary operator: {op}"))]
     /// Unsupported unary operation
     UnsupportedUnaryOperator {
         /// The unary operator that is unsupported

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -13,10 +13,11 @@ use alloc::{boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
     intermediate_ast::{
         AggregationOperator, AliasedResultExpr, BinaryOperator, Expression, Literal, OrderBy,
-        SelectResultExpr, Slice, TableExpression, UnaryOperator,
+        SelectResultExpr, Slice, TableExpression, UnaryOperator as PoSqlUnaryOperator,
     },
     Identifier, ResourceId,
 };
+use sqlparser::ast::UnaryOperator;
 
 pub struct QueryContextBuilder<'a> {
     context: QueryContext,
@@ -178,10 +179,11 @@ impl<'a> QueryContextBuilder<'a> {
 
     fn visit_unary_expr(
         &mut self,
-        op: UnaryOperator,
+        op: PoSqlUnaryOperator,
         expr: &Expression,
     ) -> ConversionResult<ColumnType> {
-        match op {
+        let sqlparser_op: UnaryOperator = op.into();
+        match sqlparser_op {
             UnaryOperator::Not => {
                 let dtype = self.visit_expr(expr)?;
                 if dtype != ColumnType::Boolean {
@@ -192,6 +194,10 @@ impl<'a> QueryContextBuilder<'a> {
                 }
                 Ok(ColumnType::Boolean)
             }
+            // Handle unsupported operators
+            _ => Err(ConversionError::UnsupportedUnaryOperator {
+                op: format!("{:?}", sqlparser_op),
+            }),
         }
     }
 

--- a/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
+++ b/crates/proof-of-sql/src/sql/parse/query_context_builder.rs
@@ -1,13 +1,16 @@
 use super::{ConversionError, ConversionResult, QueryContext};
-use crate::base::{
-    database::{
-        try_add_subtract_column_types, try_multiply_column_types, ColumnRef, ColumnType,
-        SchemaAccessor, TableRef,
+use crate::{
+    base::{
+        database::{
+            try_add_subtract_column_types, try_multiply_column_types, ColumnRef, ColumnType,
+            SchemaAccessor, TableRef,
+        },
+        math::{
+            decimal::{DecimalError, Precision},
+            BigDecimalExt,
+        },
     },
-    math::{
-        decimal::{DecimalError, Precision},
-        BigDecimalExt,
-    },
+    sql::parse::ConversionError::UnsupportedUnaryOperator,
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use proof_of_sql_parser::{
@@ -195,7 +198,7 @@ impl<'a> QueryContextBuilder<'a> {
                 Ok(ColumnType::Boolean)
             }
             // Handle unsupported operators
-            _ => Err(ConversionError::UnsupportedUnaryOperator {
+            _ => Err(UnsupportedUnaryOperator {
                 op: format!("{:?}", sqlparser_op),
             }),
         }


### PR DESCRIPTION
Please be sure to look over the pull request guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md#submit-pr.

# Please go through the following checklist
- [ ] The PR title and commit messages adhere to guidelines here: https://github.com/spaceandtimelabs/sxt-proof-of-sql/blob/main/CONTRIBUTING.md. In particular `!` is used if and only if at least one breaking change has been introduced.
- [ ] I have run the ci check script with `source scripts/run_ci_checks.sh`.

# Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the linked issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.

 Example:
 Add `NestedLoopJoinExec`.
 Closes #345.

 Since we added `HashJoinExec` in #323 it has been possible to do provable inner joins. However performance is not satisfactory in some cases. Hence we need to fix the problem by implement `NestedLoopJoinExec` and speed up the code
 for `HashJoinExec`.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.

Example:
- Add `NestedLoopJoinExec`.
- Speed up `HashJoinExec`.
- Route joins to `NestedLoopJoinExec` if the outer input is sufficiently small.
-->

# Are these changes tested?
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?

Example:
Yes.
-->
